### PR TITLE
Reverts "move" to install directory

### DIFF
--- a/tasks/install_aws_mon.yml
+++ b/tasks/install_aws_mon.yml
@@ -16,5 +16,5 @@
   when: get_script|changed
 
 - name: Move to install directory
-  command: cp /tmp/aws-scripts-mon {{cw_install_dir}}
+  command: mv /tmp/aws-scripts-mon {{cw_install_dir}}
   when: get_script|changed


### PR DESCRIPTION
(cp of dir w/o -r is broken. Also cp leaves artifacts in /tmp)