### PR TITLE
Provides cp/mv and path fixes. Installs Debian/Ubuntu Perl Dependencies

### DIFF
--- a/tasks/install_aws_mon.yml
+++ b/tasks/install_aws_mon.yml
@@ -11,10 +11,6 @@
   unarchive: src=/tmp/CloudWatchMonitoringScripts.zip dest=/tmp/ copy=no
   when: get_script|changed
 
-- name: Create install directory
-  file: path={{cw_install_dir}} state=directory
-  when: get_script|changed
-
 - name: Move to install directory
-  command: cp /tmp/aws-scripts-mon {{cw_install_dir}}
+  command: mv /tmp/aws-scripts-mon {{cw_install_dir}}
   when: get_script|changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,13 @@
     - perl-LWP-Protocol-https
     - perl-Digest-SHA
 
+- name: "Install Perl dependencies needed for Debian/Ubuntu"
+  apt: name={{item}} state=present
+  when: ansible_os_family == "Debian"
+  with_items:
+    - libwww-perl
+    - libdatetime-perl
+
 - include: install_aws_mon.yml
 
 - name: "Install wrapper arround Perl script"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for cloudwatch-monitoring
 cw_script_download_url: http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip
-cw_install_dir: /opt/aws-scripts-mon/
+cw_install_dir: /opt/aws-scripts-mon
 
 cw_options: "--disk-space-util  --disk-path=/ --disk-space-used --disk-space-avail --swap-util --swap-used --mem-util --mem-used --mem-avail"
 


### PR DESCRIPTION
1. Adds Debian/Ubuntu Perl dependency packages
2. `cp dir dir` doesn't work, as `-r` is required. Given that, I reverted this back to a `mv`, which has the benefit of avoiding cruft left in `/tmp`. This moves the extracted artifact directory to the new destination.
3. Avoids a "double-slash" in file paths, causing cron task and script with paths of `/opt/aws-scripts-mon//mon-put-instance-data.pl`


Note: Delete the .zip, /tmp, and /opt dirs (`sudo rm -rf  /opt/aws-scripts-mon/ /tmp/aws-scripts-mon/ /tmp/CloudWatchMonitoringScripts.zip`) before re-running this role, or the change here will be skipped due to `when: get_script|changed` being False.