### PR TITLE
Fixed deprecated changed filter with is check

### DIFF
--- a/tasks/install_aws_mon.yml
+++ b/tasks/install_aws_mon.yml
@@ -5,12 +5,12 @@
 
 - name: Install unzip
   package: name=unzip state=present
-  when: get_script|changed
+  when: get_script is changed
 
 - name: Unzip the scripts
   unarchive: src=/tmp/CloudWatchMonitoringScripts.zip dest=/tmp/ copy=no
-  when: get_script|changed
+  when: get_script is changed
 
 - name: Move to install directory
   command: mv /tmp/aws-scripts-mon {{cw_install_dir}}
-  when: get_script|changed
+  when: get_script is changed


### PR DESCRIPTION
When using this role with Ansible with 2.9.5 it will fail because of the deprecated `changed` filter.

```
ansible-playbook --version                                 
ansible-playbook 2.9.5
  config file = None
  configured module search path = [u'/Users/richard/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.16 (default, Jun  5 2020, 22:59:21) [GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc-
```

```
TASK [ansible-cloudwatch-monitoring : Install unzip] ***************************
task path: /Users/richard/projects/ansible/vendor/roles/ansible-cloudwatch-monitoring/tasks/install_aws_mon.yml:6
fatal: [web]: FAILED! => {
    "msg": "The conditional check 'get_script|changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if get_script|changed %} True {% else %} False {% endif %}\n\nThe error appears to be in '/Users/richard/projects/ansible/vendor/roles/ansible-cloudwatch-monitoring/tasks/install_aws_mon.yml': line 6, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Install unzip\n  ^ here\n"
}
```